### PR TITLE
#28 - 도메인 업데이트 : UserAccount 회원 Id에 유니크 키 추가

### DIFF
--- a/project-board/src/main/java/com/pf/projectboard/domain/UserAccount.java
+++ b/project-board/src/main/java/com/pf/projectboard/domain/UserAccount.java
@@ -10,7 +10,7 @@ import java.util.Objects;
 @Getter
 @ToString
 @Table(indexes = {
-        @Index(columnList = "userId"),
+        @Index(columnList = "userId", unique = true),
         @Index(columnList = "email", unique = true),
         @Index(columnList = "createdAt"),
         @Index(columnList = "createdBy")

--- a/project-board/src/test/java/com/pf/projectboard/repository/JpaRepositoryTest.java
+++ b/project-board/src/test/java/com/pf/projectboard/repository/JpaRepositoryTest.java
@@ -51,7 +51,7 @@ class JpaRepositoryTest {
     void givenTestData_whenInserting_thenWorksFine() {
         // Given
         long previousCount = articleRepository.count();
-        UserAccount userAccount = userAccountRepository.save(UserAccount.of("uno", "pw", null, null, null));
+        UserAccount userAccount = userAccountRepository.save(UserAccount.of("newFkaa", "pw", null, null, null));
         Article article = Article.of(userAccount, "new article", "new content", "#spring");
 
         // When


### PR DESCRIPTION
회원 id로 로그인하고 유저를 식별하므로 uk가 되어야 한다.
erd 설계에서 누락된 것으로 확인되었으며 추가 및 테스트 재작성

This closes #28 