### PR TITLE
#50 - Entity의 euqals() 코드 버그 수정

### DIFF
--- a/project-board/src/main/java/com/pf/projectboard/domain/Article.java
+++ b/project-board/src/main/java/com/pf/projectboard/domain/Article.java
@@ -52,8 +52,8 @@ public class Article extends AuditingFields {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof Article article)) return false;
-        return id != null && id.equals(article.id);
+        if (!(o instanceof Article that)) return false;
+        return id != null && id.equals(that.getId());
     }
 
     @Override

--- a/project-board/src/main/java/com/pf/projectboard/domain/ArticleComment.java
+++ b/project-board/src/main/java/com/pf/projectboard/domain/ArticleComment.java
@@ -41,7 +41,7 @@ public class ArticleComment extends AuditingFields {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof ArticleComment that)) return false;
-        return id != null && id.equals(that.id);
+        return id != null && id.equals(that.getId());
     }
 
     @Override

--- a/project-board/src/main/java/com/pf/projectboard/domain/UserAccount.java
+++ b/project-board/src/main/java/com/pf/projectboard/domain/UserAccount.java
@@ -45,8 +45,8 @@ public class UserAccount extends AuditingFields {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof UserAccount userAccount)) return false;
-        return userId != null && userId.equals(userAccount.userId);
+        if (!(o instanceof UserAccount that)) return false;
+        return userId != null && userId.equals(that.getUserId());
     }
 
     @Override


### PR DESCRIPTION
엔티티의 `equals()` 가 올바르게 id를 비교할 수 있도록 코드 수정