### PR TITLE
해로쿠에 배포하기(DB: ClearDB -> JawsDB)

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -39,6 +39,6 @@ spring:
 spring:
   config.activate.on-profile: heroku
   datasource:
-    url: ${CLEARDB_DATABASE_URL}
+    url: ${JAWSDB_URL}
   jpa.hibernate.ddl-auto: create
   sql.init.mode: always


### PR DESCRIPTION
ClearDB의 경우 MySql의 기본 버전이 5.6, 설정으로 올릴 수 있는 최대 한계가 5.7버전으로 로컬에서 테스트로 사용한 8.0버전과 너무 많은 차이점이 발생

JawsDB의 경우 기본 MySql DB 버전이 8.0이라서 채택 후 환경 재작업

This fixes #52 