### PR TITLE
마이페이지 추가

### DIFF
--- a/src/main/java/com/pf/projectboard/controller/UserAccountController.java
+++ b/src/main/java/com/pf/projectboard/controller/UserAccountController.java
@@ -1,0 +1,53 @@
+package com.pf.projectboard.controller;
+
+import com.pf.projectboard.dto.UserAccountDto;
+import com.pf.projectboard.dto.request.UserAccountRequest;
+import com.pf.projectboard.dto.response.UserAccountResponse;
+import com.pf.projectboard.dto.security.BoardPrincipal;
+import com.pf.projectboard.service.UserAccountService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.ModelMap;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/user")
+@Controller
+public class UserAccountController {
+
+    private final UserAccountService userAccountService;
+
+    //회원 정보를 불러온다.(마이페이지에서 사용)
+    @GetMapping("/{userId}")
+    public String showUserAccount(@PathVariable String userId, ModelMap map) {
+
+        UserAccountResponse userAccount = UserAccountResponse.from(userAccountService.getUserAccountInfo(userId));
+        map.addAttribute("userAccount", userAccount);
+        log.info(userAccount.toString());
+        System.out.println("userAccount = " + userAccount);
+
+        return "mypage";
+    }
+
+    //회원 정보를 수정한다.(마이페이지에서 사용)
+
+    //회원가입 페이지로 이동
+    @GetMapping("/signUp")
+    public String signUp() {
+        return "signUp";
+    }
+
+    //회원정보를 등록한다.(회원가입 페이지에서 사용)
+    @PostMapping("/signUp")
+    public String signUp(
+            UserAccountRequest userAccountRequest
+        ) {
+        userAccountService.saveUserAccount(userAccountRequest.toDto());
+
+        return "redirect:/";
+    }
+
+}

--- a/src/main/java/com/pf/projectboard/dto/request/UserAccountRequest.java
+++ b/src/main/java/com/pf/projectboard/dto/request/UserAccountRequest.java
@@ -1,0 +1,27 @@
+package com.pf.projectboard.dto.request;
+
+import com.pf.projectboard.dto.UserAccountDto;
+
+public record UserAccountRequest(
+        String userId,
+        String userPassword,
+        String email,
+        String nickname,
+        String memo
+) {
+
+    public static UserAccountRequest of(String userId, String userPassword, String email, String nickname, String memo) {
+        return new UserAccountRequest(userId,
+                userPassword,
+                email,
+                nickname,
+                memo);
+    }
+
+    public UserAccountDto toDto() {
+        return UserAccountDto.of(
+                userId, userPassword, email, nickname, memo
+        );
+    }
+
+}

--- a/src/main/java/com/pf/projectboard/dto/response/UserAccountResponse.java
+++ b/src/main/java/com/pf/projectboard/dto/response/UserAccountResponse.java
@@ -1,0 +1,40 @@
+package com.pf.projectboard.dto.response;
+
+import com.pf.projectboard.domain.UserAccount;
+import com.pf.projectboard.dto.UserAccountDto;
+
+public record UserAccountResponse(
+        String userId,
+        String userPassword,
+        String email,
+        String nickname,
+        String memo
+) {
+
+    public static UserAccountResponse of(String userId, String userPassword, String email, String nickname, String memo) {
+        return new UserAccountResponse(userId,
+                userPassword,
+                email,
+                nickname,
+                memo);
+    }
+
+    public static UserAccountResponse from(UserAccountDto dto) {
+        return UserAccountResponse.of(
+                dto.userId(),
+                dto.userPassword(),
+                dto.email(),
+                dto.nickname(),
+                dto.memo()
+        );
+    }
+
+    public UserAccountDto toDto() {
+        return UserAccountDto.of(
+                userId, userPassword, email, nickname, memo
+        );
+    }
+
+
+
+}

--- a/src/main/java/com/pf/projectboard/service/UserAccountService.java
+++ b/src/main/java/com/pf/projectboard/service/UserAccountService.java
@@ -1,0 +1,71 @@
+package com.pf.projectboard.service;
+
+import com.pf.projectboard.domain.UserAccount;
+import com.pf.projectboard.dto.UserAccountDto;
+import com.pf.projectboard.repository.UserAccountRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityNotFoundException;
+
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class UserAccountService {
+
+    private final UserAccountRepository userAccountRepository;
+
+    public void saveUserAccount(UserAccountDto userAccountDto) {
+        try {
+            log.warn(userAccountDto.toString());
+            if (userAccountDto.userId() != null || userAccountDto.userPassword() != null) {
+                if (userAccountDto.nickname() == null || userAccountDto.nickname().isBlank()) {
+                    userAccountDto = UserAccountDto.of(
+                            userAccountDto.userId(),
+                            userAccountDto.userPassword(),
+                            userAccountDto.email(),
+                            userAccountDto.nickname(),
+                            userAccountDto.memo());
+                }
+                userAccountRepository.save(userAccountDto.toEntity());
+            }
+        } catch (EntityNotFoundException e) {
+            log.warn("필수 입력정보에 누락이 있습니다. dto: {}" + userAccountDto);
+        }
+
+    }
+
+    public void updateUserAccount(String userId, UserAccountDto dto) {
+
+        try {
+            UserAccount userAccount = userAccountRepository.getReferenceById(userId);
+            if (userAccount.getUserId().equals(dto.userId())) {
+                if (dto.userPassword() != null ) { userAccount.setUserPassword(dto.userPassword()); }
+            }
+            userAccount.setEmail(dto.email());
+            userAccount.setNickname(dto.nickname());
+            userAccount.setMemo(dto.memo());
+//            userAccountRepository.save(userAccount);
+        } catch (EntityNotFoundException e) {
+            log.warn("회원정보 업데이트 실패, 관련된 회원정보를 찾을 수 없습니다. : {} " + e.getLocalizedMessage());
+        }
+
+    }
+
+    public void deleteUserAccount(String userId) {
+
+        userAccountRepository.deleteById(userId);
+
+    }
+
+    public UserAccountDto getUserAccountInfo(String userId) {
+
+        return userAccountRepository.findById(userId)
+                .map(UserAccountDto::from)
+                .orElseThrow(() -> new EntityNotFoundException("회원 정보가 없습니다."));
+
+    }
+}

--- a/src/main/resources/templates/articles/form.html
+++ b/src/main/resources/templates/articles/form.html
@@ -30,7 +30,7 @@
             </div>
         </div>
         <div class="row mb-3 justify-content-md-center">
-            <label for="content" class="col-sm-2 col-lg-1 col-form-label text-sm-end">본문</label>
+            <label for="content" class="col-sm-2 col-lg-1 col-form-label text-sm-end" style="resize: none">본문</label>
             <div class="col-sm-8 col-lg-9">
                 <textarea class="form-control" id="content" name="content" rows="5" required></textarea>
             </div>

--- a/src/main/resources/templates/header.html
+++ b/src/main/resources/templates/header.html
@@ -14,9 +14,10 @@
                 </ul>
 
                 <div class="text-end">
-                    <span id="username" class="text-white me-2">username</span>
+                    <a id="username" class="text-white me-2">username</a>
                     <a role="button" id="login" class="btn btn-outline-light me-2">Login</a>
                     <a role="button" id="logout" class="btn btn-outline-light me-2">Logout</a>
+<!--                    <a role="button" id="signUp" class="btn btn-outline-light me-2">Sign-Up</a>-->
                 </div>
             </div>
         </div>

--- a/src/main/resources/templates/header.th.xml
+++ b/src/main/resources/templates/header.th.xml
@@ -2,7 +2,8 @@
 <thlogic>
     <attr sel="#home" th:href="@{/}" />
     <attr sel="#hashtag" th:href="@{/articles/search-hashtag}" />
-    <attr sel="#username" sec:authorize="isAuthenticated()" sec:authentication="name" />
+    <attr sel="#username" sec:authorize="isAuthenticated()" sec:authentication="name" th:href="@{|~/user/${#authentication.name}|}"/>
     <attr sel="#login" sec:authorize="!isAuthenticated()" th:href="@{/login}" />
     <attr sel="#logout" sec:authorize="isAuthenticated()" th:href="@{/logout}" />
+<!--    <attr sel="#signUp" sec:authorize="!isAuthenticated()" th:href="@{/user/signUp}" />-->
 </thlogic>

--- a/src/main/resources/templates/mypage.html
+++ b/src/main/resources/templates/mypage.html
@@ -1,0 +1,71 @@
+<!doctype html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="">
+    <meta name="author" content="JH">
+    <title>마이페이지</title>
+
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-0evHe/X+R7YkIZDRvuzKMRqM+OrBnVFBL6DOitfPri4tjfHxaWutUpFmBp4vmVor" crossorigin="anonymous">
+
+</head>
+<body class="bg-light">
+
+<div class="container">
+    <main id="mypage-main">
+        <div class="py-5 text-center">
+            <h2>마이페이지</h2>
+        </div>
+
+        <div class="row g-5 justify-content-center">
+            <div class="col-md-6 col-lg-6">
+                <form class="needs-validation">
+                    <div class="col g-3">
+
+                        <div class="col-12 my-3">
+                            <label id="idLabel" for="id" class="form-label">ID</label>
+                            <input type="text" class="form-control" id="id" value="ID" required readonly>
+                        </div>
+
+                        <div class="col-12 my-3">
+                            <label id="pwLabel" for="password" class="form-label">비밀번호</label>
+                            <input type="text" class="form-control" id="password" value="PW" required readonly>
+                        </div>
+
+                        <div class="col-12 my-3">
+                            <label id="mailLabel" for="email" class="form-label">Email</label>
+                            <input type="email" class="form-control" id="email" value="example@example.com" readonly>
+                        </div>
+
+                        <div class="col-12 my-3">
+                            <label for="nickname" class="form-label">닉네임</label>
+                            <input type="text" class="form-control" id="nickname" value="nickname" readonly>
+                        </div>
+
+                        <div class="col-12 my-3">
+                            <label for="userMemo" class="form-label">메모</label>
+                            <textarea class="form-control" id="userMemo" rows="5" style="resize: none" readonly>메모</textarea>
+                        </div>
+                    </div>
+                    <hr class="my-4">
+
+<!--                    <button class="w-100 btn btn-primary btn-lg" type="submit">회원가입 완료</button>-->
+                </form>
+            </div>
+        </div>
+    </main>
+
+    <footer class="my-5 pt-5 text-muted text-center text-small">
+        <p class="mb-1">&copy; 2022 PortFolio-Board</p>
+        <ul class="list-inline">
+            <li class="list-inline-item"><a href="/">HOME</a></li>
+        </ul>
+    </footer>
+</div>
+
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/js/bootstrap.bundle.min.js" integrity="sha384-pprn3073KE6tl6bjs2QrFaJGz5/SUsLqktiwsUTF55Jfv3qYSDhgCecCxMW52nD2" crossorigin="anonymous"></script>
+
+</body>
+</html>

--- a/src/main/resources/templates/mypage.th.xml
+++ b/src/main/resources/templates/mypage.th.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<thlogic>
+    <attr sel="#header" th:replace="header::header" />
+    <attr sel="#footer" th:replace="footer::footer" />
+    <attr sel="#mypage-main" th:object="${userAccount}">
+        <attr sel="#id" th:value="*{userId}" />
+        <attr sel="#password" th:value="*{#strings.substring(userPassword,6,#strings.length(userPassword))}" />
+        <attr sel="#email" th:value="*{email}" />
+        <attr sel="#nickname" th:value="*{nickname}" />
+        <attr sel="#userMemo" th:text="*{memo}" />
+    </attr>
+<!--    <attr sel="#home" th:href="@{/}" />-->
+<!--    <attr sel="#hashtag" th:href="@{/articles/search-hashtag}" />-->
+<!--    <attr sel="#username" sec:authorize="isAuthenticated()" sec:authentication="name" />-->
+<!--    <attr sel="#login" sec:authorize="!isAuthenticated()" th:href="@{/login}" />-->
+<!--    <attr sel="#logout" sec:authorize="isAuthenticated()" th:href="@{/logout}" />-->
+</thlogic>

--- a/src/test/java/com/pf/projectboard/controller/UserAccountControllerTest.java
+++ b/src/test/java/com/pf/projectboard/controller/UserAccountControllerTest.java
@@ -1,0 +1,102 @@
+package com.pf.projectboard.controller;
+
+import com.pf.projectboard.config.TestSecurityConfig;
+import com.pf.projectboard.domain.UserAccount;
+import com.pf.projectboard.dto.UserAccountDto;
+import com.pf.projectboard.dto.response.UserAccountResponse;
+import com.pf.projectboard.service.UserAccountService;
+import com.pf.projectboard.util.FormDataEncoder;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@DisplayName("View Controller - 회원")
+@Import({TestSecurityConfig.class, FormDataEncoder.class})
+@WebMvcTest(UserAccountController.class)
+class UserAccountControllerTest {
+
+    private final MockMvc mvc;
+    private final FormDataEncoder formDataEncoder;
+
+    @MockBean private UserAccountService userAccountService;
+
+    UserAccountControllerTest(
+            @Autowired MockMvc mvc,
+            @Autowired FormDataEncoder formDataEncoder) {
+        this.mvc = mvc;
+        this.formDataEncoder = formDataEncoder;
+    }
+
+    @WithMockUser
+    @DisplayName("1. 회원 마이페이지 호출 - 정상호출")
+    @Test
+    void givenNothing_whenRequestingMyPage_thenReturnsMyPage() throws Exception {
+        //given
+        String userId = "testId";
+        UserAccountDto dto = createdUserAccountDto();
+        given(userAccountService.getUserAccountInfo(userId)).willReturn(dto);
+
+        //when & then
+        mvc.perform(get("/user/" + userId))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+                .andExpect(view().name("mypage"))
+                .andExpect(model().attribute("userAccount", UserAccountResponse.from(dto)));
+        then(userAccountService).should().getUserAccountInfo(userId);
+
+    }
+
+    @DisplayName("2. 회원가입 페이지 호출 - 정상 호출")
+    @Test
+    void givenNothing_whenRequestingSignUpView_ReturnsSignUpView() throws Exception {
+        //given
+
+
+        //when & then
+        mvc.perform(get("/user/signUp"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+                .andExpect(view().name("signUp"));
+
+    }
+
+    private UserAccount createdUserAccount() {
+        return UserAccount.of(
+                "testId",
+                "testPw",
+                "test@email.com",
+                "testNick",
+                "testMemo"
+        );
+    }
+
+    private UserAccountDto createdUserAccountDto() {
+        return UserAccountDto.of(
+                "testId",
+                "testPw",
+                "test@email.com",
+                "testNick",
+                "testMemo"
+        );
+    }
+
+    private UserAccountDto createdUserAccountDto(String pw, String email, String nickname, String memo) {
+        return UserAccountDto.of(
+                "testId",
+                pw, email, nickname, memo
+        );
+    }
+}

--- a/src/test/java/com/pf/projectboard/service/UserAccountServiceTest.java
+++ b/src/test/java/com/pf/projectboard/service/UserAccountServiceTest.java
@@ -1,0 +1,129 @@
+package com.pf.projectboard.service;
+
+import com.pf.projectboard.domain.Article;
+import com.pf.projectboard.domain.UserAccount;
+import com.pf.projectboard.dto.UserAccountDto;
+import com.pf.projectboard.repository.UserAccountRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.*;
+
+@DisplayName("비즈니스 로직 - 회원")
+@ExtendWith(MockitoExtension.class)
+class UserAccountServiceTest {
+
+    @InjectMocks private UserAccountService sut;
+
+    @Mock private UserAccountRepository userAccountRepository;
+
+    @DisplayName("1. 회원정보를 입력 후 회원가입 - 정상 호출")
+    @Test
+    void givenUserAccountInfo_whenSavingUserAccount_thenSavesUserAccount() {
+        //given
+        UserAccountDto accountDto = createdUserAccountDto();
+        given(userAccountRepository.save(any(UserAccount.class))).willReturn(createdUserAccount());
+
+        //when
+        sut.saveUserAccount(accountDto);
+
+        // then
+        then(userAccountRepository).should().save(any(UserAccount.class));
+
+    }
+
+    @DisplayName("2. 회원 수정 정보를 입력하면, 회원정보 업데이트")
+    @Test
+    void givenUserAccountInfo_whenUpdatingUserAccount_thenUpdatesUserAccount() {
+        //given
+        UserAccount userAccount = createdUserAccount();
+        UserAccountDto dto = createdUserAccountDto("updatedPw", "updated@mail.com", "updatedNickname","updatedMemo");
+        given(userAccountRepository.getReferenceById(userAccount.getUserId())).willReturn(userAccount);
+
+        //when
+        sut.updateUserAccount(userAccount.getUserId(), dto);
+
+        //then
+        assertThat(userAccount)
+                .hasFieldOrPropertyWithValue("userPassword", dto.userPassword())
+                .hasFieldOrPropertyWithValue("email", dto.email())
+                .hasFieldOrPropertyWithValue("nickname", dto.nickname())
+                .hasFieldOrPropertyWithValue("memo", dto.memo());
+        then(userAccountRepository).should().getReferenceById(dto.userId());
+
+    }
+
+    @DisplayName("3. 회원 아이디가 주어지면, 회원 탈퇴")
+    @Test
+    void givenUserId_whenDeletingUserAccount_thenDeletesUserAccount() {
+        //given
+        String userId = "testId";
+        willDoNothing().given(userAccountRepository).deleteById(userId);
+
+        //when
+        sut.deleteUserAccount(userId);
+
+        //then
+        then(userAccountRepository).should().deleteById(userId);
+
+    }
+
+    @DisplayName("4. 회원 ID와 비밀번호가 주어지면, 해당하는 회원의 정보를 가져온다.")
+    @Test
+    void givenUserIdAndUserPassword_whenResponsingUserInfo_thenResponseUserInfo() {
+        //given
+        UserAccount userAccount = createdUserAccount();
+        String userId = "testId";
+        String password = "testPw";
+        given(userAccountRepository.findById(userId)).willReturn(Optional.of(userAccount));
+
+        System.out.println("userAccount = " + userAccount);
+
+        //when & then
+        UserAccountDto dto = sut.getUserAccountInfo(userId);
+        assertThat(dto)
+                .hasFieldOrPropertyWithValue("userId", userAccount.getUserId())
+                .hasFieldOrPropertyWithValue("userPassword", userAccount.getUserPassword())
+                .hasFieldOrPropertyWithValue("email", userAccount.getEmail())
+                .hasFieldOrPropertyWithValue("nickname", userAccount.getNickname())
+                .hasFieldOrPropertyWithValue("memo", userAccount.getMemo());
+        then(userAccountRepository).should().findById(userId);
+
+    }
+
+    private UserAccount createdUserAccount() {
+        return UserAccount.of(
+                "testId",
+                "testPw",
+                "test@email.com",
+                "testNick",
+                "testMemo"
+        );
+    }
+
+    private UserAccountDto createdUserAccountDto() {
+        return UserAccountDto.of(
+                "testId",
+                "testPw",
+                "test@email.com",
+                "testNick",
+                "testMemo"
+        );
+    }
+
+    private UserAccountDto createdUserAccountDto(String pw, String email, String nickname, String memo) {
+        return UserAccountDto.of(
+                "testId",
+                pw, email, nickname, memo
+        );
+    }
+
+}


### PR DESCRIPTION
회원정보를 조회하는 마이페이지 기능 활성화를 위해 
자바 코드에서는 `UserAccountController`, `UserAcccountService`
`UserAccountResponse`, `UserAccountRequest` 신규 작성
`UserAccountController`와 `UserAccountService`는 테스트 코드도 작성

뷰 추가로는 `Header.html`과 `Header.th.xml`을 수정하여 상단의 회원 아이디에 `a태그`를 추가하여 링크 활성화
마이페이지는 `mypage.html`과 디커플로 `mypage.th.xml` 추가

This closes #56 
